### PR TITLE
Better support for numpy.ndarray

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ print("version    = {}"     .format(data.header.file_version))
 print("image size = {}x{}"  .format(data.header.x_pixel, data.header.y_pixel))
 print("there are {} frames.".format(len(data.frames)))
 
-frame_0 = np.array(data.frames[0].data, copy = False)
-plt.imshow(frame_0)
+plt.imshow(data.frames[0].image())
 plt.show()
 ```
 
@@ -68,10 +67,18 @@ types at a compile time, statically.
 
 ### With NumPy
 
-Because libasd aims the interoperability with NumPy, libasd returns a frame object
-by using `Buffer protocol` relying on pybind11.
-It enables users to cast a `libasd.Frame` object to NumPy Array __without__
-copying all the elements in the frame (don't forget to set `copy = False`).
+Because libasd aims the interoperability with NumPy, `frame.image()` function
+returns `numpy.ndarray`.
+
+```python
+img = data.frames[0].image() # img is numpy.ndarray
+```
+
+`libasd.Frame` also has `data` object as a member that contains the same
+information as the return value of `image`.
+It uses `Buffer protocol` relying on pybind11 that enables users to cast
+a `libasd.Frame` object to NumPy Array __without__ copying all the elements
+in the frame (don't forget to set `copy = False`).
 
 ```python
 import libasd
@@ -82,7 +89,7 @@ data = libasd.read_asd("example.asd")
 
 # cast frame data into numpy Array
 frame_0 = np.array(data.frames[0].data, copy = False)
-````
+```
 
 To manipulate the frame datas, it is recommended to cast the data to the NumPy
 Arrays.

--- a/python/libasd_py.cpp
+++ b/python/libasd_py.cpp
@@ -1,5 +1,6 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/numpy.h>
 #include <libasd/libasd.hpp>
 #include <fstream>
 
@@ -457,6 +458,18 @@ void add_frame_classes(py::module& mod) // {{{
                        "type: FrameHeader\nheader of this frame")
         .def_readwrite("data",   &asd::Frame<std::int16_t, asd::ch<1>, asd::container::vec>::data,
                        "type: FrameData<Integer>\narray that represents the image. raw data without conversion into [nm]")
+        .def("image", [](asd::Frame<std::int16_t, asd::ch<1>, asd::container::vec>* self)
+                -> py::array_t<std::int16_t> {
+                return py::array_t<std::int16_t>(py::buffer_info(
+                    self->data.base().data(), sizeof(std::int16_t),
+                    py::format_descriptor<std::int16_t>::format(),
+                    2, {self->data.x_pixel(), self->data.y_pixel()},
+                    {sizeof(std::int16_t) * self->data.x_pixel(), sizeof(std::int16_t)}
+                ));
+            },
+            "array that represents the image.\n"
+            "each pixel represents the heigths at that point in [nm].\n"
+            "The data is the same as `data` member variable.")
         ;
 
     py::class_<asd::Frame<std::int16_t, asd::ch<2>, asd::container::vec>
@@ -466,6 +479,20 @@ void add_frame_classes(py::module& mod) // {{{
                        "type: FrameHeader\nheader of this frame")
         .def_readwrite("data",   &asd::Frame<std::int16_t, asd::ch<2>, asd::container::vec>::data,
                        "type: FrameData<Integer>\narray that represents the image. raw data without conversion into [nm]")
+        .def("image", [](asd::Frame<std::int16_t, asd::ch<2>, asd::container::vec>* self, std::size_t i)
+                -> py::array_t<std::int16_t> {
+                return py::array_t<std::int16_t>(py::buffer_info(
+                    self->data.at(i).base().data(), sizeof(std::int16_t),
+                    py::format_descriptor<std::int16_t>::format(),
+                    2, {self->data.at(i).x_pixel(), self->data.at(i).y_pixel()},
+                    {sizeof(std::int16_t) * self->data.at(i).x_pixel(), sizeof(std::int16_t)}
+                ));
+            },
+            "parameter: index: channel index.\n"
+            "array that represents the image. each pixel represents the heigths at that point in [nm].\n"
+            "The data is the same as `data` member variable.",
+            py::arg("index")
+            )
         ;
 
     py::class_<asd::Frame<double, asd::ch<1>, asd::container::vec>
@@ -475,6 +502,18 @@ void add_frame_classes(py::module& mod) // {{{
                        "type: FrameHeader\nheader of this frame")
         .def_readwrite("data",   &asd::Frame<double, asd::ch<1>, asd::container::vec>::data,
                        "type: FrameData<Float>\narray that represents the heights of each pixel in [nm]")
+        .def("image", [](asd::Frame<double, asd::ch<1>, asd::container::vec>* self)
+                -> py::array_t<double> {
+                return py::array_t<double>(py::buffer_info(
+                    self->data.base().data(), sizeof(double),
+                    py::format_descriptor<double>::format(),
+                    2, {self->data.x_pixel(), self->data.y_pixel()},
+                    {sizeof(double) * self->data.x_pixel(), sizeof(double)}
+                ));
+            },
+            "array that represents the image.\n"
+            "each pixel represents the heigths at that point in [nm].\n"
+            "The data is the same as `data` member variable.")
         ;
 
     py::class_<asd::Frame<double, asd::ch<2>, asd::container::vec>
@@ -484,6 +523,19 @@ void add_frame_classes(py::module& mod) // {{{
                        "type: FrameHeader\nheader of this frame")
         .def_readwrite("data",   &asd::Frame<double, asd::ch<2>, asd::container::vec>::data,
                        "type: FrameData<Float>\narray that represents the heights of each pixel in [nm]")
+        .def("image", [](asd::Frame<double, asd::ch<2>, asd::container::vec>* self, std::size_t i)
+                -> py::array_t<double> {
+                return py::array_t<double>(py::buffer_info(
+                    self->data.at(i).base().data(), sizeof(double),
+                    py::format_descriptor<double>::format(),
+                    2, {self->data.at(i).x_pixel(), self->data.at(i).y_pixel()},
+                    {sizeof(double) * self->data.at(i).x_pixel(), sizeof(double)}
+                ));
+            },
+            "parameter: index: channel index.\n"
+            "array that represents the image. each pixel represents the heigths at that point in [nm].\n",
+            py::arg("index")
+            )
         ;
 
     return;


### PR DESCRIPTION
add `image()` function to `Frame` to return `numpy.ndarray` itself.
It removes the need for manual conversion.

```python
data = libasd.read_asd("example.asd")

img = numpy.array(data.frame[0].data, copy = False) # current
img = data.frame[0].image() # this PR
```