### PR TITLE
make AD_range useful

### DIFF
--- a/libasd/header.hpp
+++ b/libasd/header.hpp
@@ -20,6 +20,26 @@ enum class AD_range : std::uint32_t
     dummy_value   = 0x00800000, //!< dummy value(80[V]). & resolution -> 16bit.
 };
 
+template<typename Real>
+std::pair<Real, Real> to_voltage(const AD_range range)
+{
+    switch(range)
+    {
+        case AD_range::unipolar_1_0V: {return std::make_pair(  0.0,  1.0);}
+        case AD_range::unipolar_2_5V: {return std::make_pair(  0.0,  2.5);}
+        case AD_range::unipolar_5_0V: {return std::make_pair(  0.0,  5.0);}
+        case AD_range::bipolar_1_0V : {return std::make_pair( -1.0,  1.0);}
+        case AD_range::bipolar_2_5V : {return std::make_pair( -2.5,  2.5);}
+        case AD_range::bipolar_5_0V : {return std::make_pair( -5.0,  5.0);}
+        case AD_range::dummy_value  : {return std::make_pair(-80.0, 80.0);}
+        default:
+        {
+            throw std::runtime_error("invalid AD_range: " +
+                     std::to_string(static_cast<std::uint32_t>(range)));
+        }
+    }
+}
+
 template<typename charT, typename traitsT>
 std::basic_ostream<charT, traitsT>&
 operator<<(std::basic_ostream<charT, traitsT>& os, const AD_range adr)

--- a/python/libasd_py.cpp
+++ b/python/libasd_py.cpp
@@ -10,12 +10,12 @@ namespace py = pybind11;
 void add_header_enums(py::module& mod) // {{{
 {
     py::enum_<asd::AD_range>(mod, "AD_range", py::arithmetic())
-        .value("unipolar_1.0V", asd::AD_range::unipolar_1_0V)
-        .value("unipolar_2.5V", asd::AD_range::unipolar_2_5V)
-        .value("unipolar_5.0V", asd::AD_range::unipolar_5_0V)
-        .value("bipolar_1.0V",  asd::AD_range::bipolar_1_0V)
-        .value("bipolar_2.5V",  asd::AD_range::bipolar_2_5V)
-        .value("bipolar_5.0V",  asd::AD_range::bipolar_5_0V)
+        .value("unipolar_1_0V", asd::AD_range::unipolar_1_0V)
+        .value("unipolar_2_5V", asd::AD_range::unipolar_2_5V)
+        .value("unipolar_5_0V", asd::AD_range::unipolar_5_0V)
+        .value("bipolar_1_0V",  asd::AD_range::bipolar_1_0V)
+        .value("bipolar_2_5V",  asd::AD_range::bipolar_2_5V)
+        .value("bipolar_5_0V",  asd::AD_range::bipolar_5_0V)
         .value("dummy_value",   asd::AD_range::dummy_value)
         .export_values();
 

--- a/python/libasd_py.cpp
+++ b/python/libasd_py.cpp
@@ -42,6 +42,13 @@ void add_header_enums(py::module& mod) // {{{
         .value("none",       asd::data_kind::none)
         .export_values();
 
+    mod.def("to_voltage",
+        [](const asd::AD_range range) -> std::pair<double, double> {
+            return asd::to_voltage<double>(range);
+        }, py::arg("AD_range"), "This function converts AD_range enum into a "
+        "pair of floats that correspond to the minimum and maximum voltage [V]."
+        );
+
     return;
 } // }}}
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,7 @@ set(TEST_NAMES
     test_read_binary_as
     test_write_as_binary
     test_frame_data
+    test_header_enums
     )
 
 if(${Boost_FOUND})

--- a/test/test_header_enums.cpp
+++ b/test/test_header_enums.cpp
@@ -1,0 +1,55 @@
+#include <libasd/header.hpp>
+#include <boost/test/included/unit_test.hpp>
+#include <boost/mpl/list.hpp>
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(to_voltage, T)
+{
+    {
+        const auto minmax = asd::to_voltage<T>(asd::AD_range::unipolar_1_0V);
+        BOOST_CHECK_EQUAL(minmax.first,  0.0);
+        BOOST_CHECK_EQUAL(minmax.second, 1.0);
+    }
+    {
+        const auto minmax = asd::to_voltage<T>(asd::AD_range::unipolar_2_5V);
+        BOOST_CHECK_EQUAL(minmax.first,  0.0);
+        BOOST_CHECK_EQUAL(minmax.second, 2.5);
+    }
+    {
+        const auto minmax = asd::to_voltage<T>(asd::AD_range::unipolar_5_0V);
+        BOOST_CHECK_EQUAL(minmax.first,  0.0);
+        BOOST_CHECK_EQUAL(minmax.second, 5.0);
+    }
+    {
+        const auto minmax = asd::to_voltage<T>(asd::AD_range::bipolar_1_0V);
+        BOOST_CHECK_EQUAL(minmax.first, -1.0);
+        BOOST_CHECK_EQUAL(minmax.second, 1.0);
+    }
+    {
+        const auto minmax = asd::to_voltage<T>(asd::AD_range::bipolar_2_5V);
+        BOOST_CHECK_EQUAL(minmax.first, -2.5);
+        BOOST_CHECK_EQUAL(minmax.second, 2.5);
+    }
+    {
+        const auto minmax = asd::to_voltage<T>(asd::AD_range::bipolar_5_0V);
+        BOOST_CHECK_EQUAL(minmax.first, -5.0);
+        BOOST_CHECK_EQUAL(minmax.second, 5.0);
+    }
+    {
+        const auto minmax = asd::to_voltage<T>(asd::AD_range::dummy_value);
+        BOOST_CHECK_EQUAL(minmax.first, -80.0);
+        BOOST_CHECK_EQUAL(minmax.second, 80.0);
+    }
+}
+
+boost::unit_test::test_suite*
+init_unit_test_suite(int, char**)
+{
+    typedef boost::mpl::list<float, double> real_types;
+
+    boost::unit_test::framework::master_test_suite()
+        .add(BOOST_TEST_CASE_TEMPLATE(to_voltage, real_types));
+
+    return 0;
+}
+
+


### PR DESCRIPTION
- add `to_voltage` function to both C++ and python API
  - it converts `AD_range` values into pair of floats `(min [V], max [V])`
- **breaking**: rename `AD_range` enum values in python
  - `unipolar_1.0V` -> `unipolar_1_0V`