### PR TITLE
sdist build and update of CMake

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,13 @@
 name: release
 
 on:
-  release:
-    types: [published]
+  push:
+  # release:
+  #   types: [published]
 
 jobs:
   test-linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -51,11 +52,11 @@ jobs:
       - name: Build
         run: |
             python setup.py bdist_wheel -p manylinux1_x86_64
-      - name: Upload
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-            user: __token__
-            password: ${{ secrets.pypi_token }}
+      # - name: Upload
+      #   uses: pypa/gh-action-pypi-publish@master
+      #   with:
+      #       user: __token__
+      #       password: ${{ secrets.pypi_token }}
   test-windows:
     runs-on: windows-2019
     strategy:
@@ -103,9 +104,9 @@ jobs:
       - name: Build
         run: |
             python setup.py bdist_wheel
-      - name: Upload
-        run: |
-            python -m twine upload dist/* --username __token__ --password "${{ secrets.pypi_token }}"
+      # - name: Upload
+      #   run: |
+      #       python -m twine upload dist/* --username __token__ --password "${{ secrets.pypi_token }}"
   test-macos:
     runs-on: macos-10.15
     steps:
@@ -148,6 +149,32 @@ jobs:
       - name: Build
         run: |
             python setup.py bdist_wheel
-      - name: Upload
+      # - name: Upload
+      #   run: |
+      #       python -m twine upload dist/* --username __token__ --password "${{ secrets.pypi_token }}"
+  upload-source:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+            submodules: true
+      - name: Configuration
+        uses: actions/setup-python@v2
+        with:
+            python-version: ${{ matrix.python-version }}
+            architecture: x64
+      - name: Install
         run: |
-            python -m twine upload dist/* --username __token__ --password "${{ secrets.pypi_token }}"
+            python -m pip install wheel
+      - name: Build
+        run: |
+            python setup.py sdist -p manylinux1_x86_64
+      # - name: Upload
+      #   uses: pypa/gh-action-pypi-publish@master
+      #   with:
+      #       user: __token__
+      #       password: ${{ secrets.pypi_token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,12 @@
 name: release
 
 on:
-  push:
-  # release:
-  #   types: [published]
+  release:
+    types: [published]
 
 jobs:
   test-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -52,11 +51,11 @@ jobs:
       - name: Build
         run: |
             python setup.py bdist_wheel -p manylinux1_x86_64
-      # - name: Upload
-      #   uses: pypa/gh-action-pypi-publish@master
-      #   with:
-      #       user: __token__
-      #       password: ${{ secrets.pypi_token }}
+      - name: Upload
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+            user: __token__
+            password: ${{ secrets.pypi_token }}
   test-windows:
     runs-on: windows-2019
     strategy:
@@ -104,9 +103,9 @@ jobs:
       - name: Build
         run: |
             python setup.py bdist_wheel
-      # - name: Upload
-      #   run: |
-      #       python -m twine upload dist/* --username __token__ --password "${{ secrets.pypi_token }}"
+      - name: Upload
+        run: |
+            python -m twine upload dist/* --username __token__ --password "${{ secrets.pypi_token }}"
   test-macos:
     runs-on: macos-10.15
     steps:
@@ -149,9 +148,9 @@ jobs:
       - name: Build
         run: |
             python setup.py bdist_wheel
-      # - name: Upload
-      #   run: |
-      #       python -m twine upload dist/* --username __token__ --password "${{ secrets.pypi_token }}"
+      - name: Upload
+        run: |
+            python -m twine upload dist/* --username __token__ --password "${{ secrets.pypi_token }}"
   upload-source:
     runs-on: ubuntu-20.04
     strategy:
@@ -169,12 +168,10 @@ jobs:
             architecture: x64
       - name: Install
         run: |
-            python -m pip install wheel
+            python -m pip install wheel twine
       - name: Build
         run: |
-            python setup.py sdist -p manylinux1_x86_64
-      # - name: Upload
-      #   uses: pypa/gh-action-pypi-publish@master
-      #   with:
-      #       user: __token__
-      #       password: ${{ secrets.pypi_token }}
+            python setup.py sdist
+      - name: Upload
+        run: |
+            python -m twine upload dist/* --username __token__ --password "${{ secrets.pypi_token }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "cmake", ]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,17 @@
+[metadata]
+name = libasd
+version = 1.5.5
+author = Toru Niina
+author_email = niina.toru.68u@gmail.com
+url = https://github.com/ToruNiina/libasd
+description = A library to read High Speed AFM data file
+long_description =
+
+[options]
+zip_safe = False
+
+install_requires =
+  cmake
+  wheel
+
+package = find:

--- a/setup.py
+++ b/setup.py
@@ -2,70 +2,120 @@
 import os
 import re
 import sys
-import platform
 import subprocess
+from pathlib import Path
 
+from setuptools import setup, Extension
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 from distutils.version import LooseVersion
 
 
+# A CMakeExtension needs a sourcedir instead of a file list.
+# The name must be the _single_ output extension from the CMake build.
+# If you need multiple extensions, see scikit-build.
 class CMakeExtension(Extension):
-    def __init__(self, name, sourcedir=''):
-        Extension.__init__(self, name, sources=[])
-        self.sourcedir = os.path.abspath(sourcedir)
+    def __init__(self, name: str, sourcedir: str = "") -> None:
+        super().__init__(name, sources=[])
+        self.sourcedir = os.fspath(Path(sourcedir).resolve())
+
 
 class CMakeBuild(build_ext):
-    def run(self):
-        try:
-            out = subprocess.check_output(['cmake', '--version'])
-        except OSError:
-            raise RuntimeError("CMake must be installed to build the following extensions: " +
-                               ", ".join(e.name for e in self.extensions))
+    def build_extension(self, ext: CMakeExtension) -> None:
+        # Must be in this form due to bug in .resolve() only fixed in Python 3.10+
+        ext_fullpath = Path.cwd() / self.get_ext_fullpath(ext.name)  # type: ignore[no-untyped-call]
+        extdir = ext_fullpath.parent.resolve()
 
-        if platform.system() == "Windows":
-            cmake_version = LooseVersion(re.search(r'version\s*([\d.]+)', out.decode()).group(1))
-            if cmake_version < '3.1.0':
-                raise RuntimeError("CMake >= 3.1.0 is required on Windows")
+        # Using this requires trailing slash for auto-detection & inclusion of
+        # auxiliary "native" libs
 
-        for ext in self.extensions:
-            self.build_extension(ext)
+        debug = int(os.environ.get("DEBUG", 0)) if self.debug is None else self.debug
+        cfg = "Debug" if debug else "Release"
 
-    def build_extension(self, ext):
-        extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
-        cmake_args = ['-DLIBASD_BUILD_TESTS=OFF',
-                      '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
-                      '-DPYTHON_EXECUTABLE=' + sys.executable]
+        # CMake lets you override the generator - we need to check this.
+        # Can be set with Conda-Build, for example.
+        cmake_generator = os.environ.get("CMAKE_GENERATOR", "")
 
-        cfg = 'Debug' if self.debug else 'Release'
-        build_args = ['--config', cfg]
+        # Set Python_EXECUTABLE instead if you use PYBIND11_FINDPYTHON
+        # EXAMPLE_VERSION_INFO shows you how to pass a value into the C++ code
+        # from Python.
+        cmake_args = [
+            f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}{os.sep}",
+            f"-DPYTHON_EXECUTABLE={sys.executable}",
+            f"-DCMAKE_BUILD_TYPE={cfg}",  # not used on MSVC, but no harm
+        ]
+        build_args = []
+        # Adding CMake arguments set as environment variable
+        # (needed e.g. to build for ARM OSx on conda-forge)
+        if "CMAKE_ARGS" in os.environ:
+            cmake_args += [item for item in os.environ["CMAKE_ARGS"].split(" ") if item]
 
-        if platform.system() == "Windows":
-            cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir)]
-            if sys.maxsize > 2**32:
-                cmake_args += ['-A', 'x64']
-            build_args += ['--', '/m']
+        # In this example, we pass in the version to C++. You might not need to.
+        cmake_args += [f"-DEXAMPLE_VERSION_INFO={self.distribution.get_version()}"]  # type: ignore[attr-defined]
+
+        if self.compiler.compiler_type != "msvc":
+            # Using Ninja-build since it a) is available as a wheel and b)
+            # multithreads automatically. MSVC would require all variables be
+            # exported for Ninja to pick it up, which is a little tricky to do.
+            # Users can override the generator with CMAKE_GENERATOR in CMake
+            # 3.15+.
+            if not cmake_generator or cmake_generator == "Ninja":
+                try:
+                    import ninja  # noqa: F401
+
+                    ninja_executable_path = Path(ninja.BIN_DIR) / "ninja"
+                    cmake_args += [
+                        "-GNinja",
+                        f"-DCMAKE_MAKE_PROGRAM:FILEPATH={ninja_executable_path}",
+                    ]
+                except ImportError:
+                    pass
+
         else:
-            cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
-            build_args += ['--', '-j2']
 
-        env = os.environ.copy()
-        env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''),
-                                                              self.distribution.get_version())
-        if not os.path.exists(self.build_temp):
-            os.makedirs(self.build_temp)
-        subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
-        subprocess.check_call(['cmake', '--build', '.'] + build_args, cwd=self.build_temp)
+            # Single config generators are handled "normally"
+            single_config = any(x in cmake_generator for x in {"NMake", "Ninja"})
+
+            # CMake allows an arch-in-generator style for backward compatibility
+            contains_arch = any(x in cmake_generator for x in {"ARM", "Win64"})
+
+            # Specify the arch if using MSVC generator, but only if it doesn't
+            # contain a backward-compatibility arch spec already in the
+            # generator name.
+            if not single_config and not contains_arch:
+                cmake_args += ["-A", PLAT_TO_CMAKE[self.plat_name]]
+
+            # Multi-config generators have a different way to specify configs
+            if not single_config:
+                cmake_args += [f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{cfg.upper()}={extdir}"]
+                build_args += ["--config", cfg]
+
+        if sys.platform.startswith("darwin"):
+            # Cross-compile support for macOS - respect ARCHFLAGS if set
+            archs = re.findall(r"-arch (\S+)", os.environ.get("ARCHFLAGS", ""))
+            if archs:
+                cmake_args += ["-DCMAKE_OSX_ARCHITECTURES={}".format(";".join(archs))]
+
+        # Set CMAKE_BUILD_PARALLEL_LEVEL to control the parallel build level
+        # across all generators.
+        if "CMAKE_BUILD_PARALLEL_LEVEL" not in os.environ:
+            # self.parallel is a Python 3 only way to set parallel jobs by hand
+            # using -j in the build_ext call, not supported by pip or PyPA-build.
+            if hasattr(self, "parallel") and self.parallel:
+                # CMake 3.12+ only.
+                build_args += [f"-j{self.parallel}"]
+
+        build_temp = Path(self.build_temp) / ext.name
+        if not build_temp.exists():
+            build_temp.mkdir(parents=True)
+
+        print("##### GOING TO BUILD!!!")
+        subprocess.run(["cmake", ext.sourcedir] + cmake_args, cwd=build_temp, check=True)
+        subprocess.run(["cmake", "--build", "."] + build_args, cwd=build_temp, check=True)
+        print("##### BUILDING DONE")
+
 
 setup(
-    name='libasd',
-    version='1.5.5',
-    author='Toru Niina',
-    author_email='niina.toru.68u@gmail.com',
-    url='https://github.com/ToruNiina/libasd',
-    description='a library to read High Speed AFM data file',
-    long_description='',
-    ext_modules=[CMakeExtension('libasd')],
+    ext_modules=[CMakeExtension("libasd")],
     cmdclass=dict(build_ext=CMakeBuild),
-    zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,6 @@ class CMakeBuild(build_ext):
         if "CMAKE_ARGS" in os.environ:
             cmake_args += [item for item in os.environ["CMAKE_ARGS"].split(" ") if item]
 
-        # In this example, we pass in the version to C++. You might not need to.
-        cmake_args += [f"-DEXAMPLE_VERSION_INFO={self.distribution.get_version()}"]  # type: ignore[attr-defined]
-
         if self.compiler.compiler_type != "msvc":
             # Using Ninja-build since it a) is available as a wheel and b)
             # multithreads automatically. MSVC would require all variables be


### PR DESCRIPTION
Closes #8 
Closes #11

Hi @ToruNiina 

I'm working with the [AFM-SPM](https://github.com/AFM-SPM/) group on [TopoStats](https://github.com/AFM-SPM/TopoStats/) a package for processing AFM images and we're keen to support `.asd` files so have been looking at your `libasd` library. It works great but we encountered an issue as a couple of our team members use Apple Macs with ARM chips and there were no binaries (see #11 ). I read through #8 and realised that a possible solution was to make an `sdist` available and have such systems download and build the source code.

I noticed you'd based your `setup.py` on `pybind/cmake_example` and so have updated to the latest example, moving metadata to `setup.cfg` and introducing `pyproject.toml`.

At the same time I've added an `upload-source` job to `.github/workflows/release.yml` that should, I hope, also build the `sdist` and upload it to PyPI when you publish releases.

Any feedback on this PR is very welcome and I'm keen to work through any issues.

Thanks, @ns-rse