### PR TITLE
Bump version to 1.5.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = libasd
-version = 1.5.5
+version = 1.5.6
 author = Toru Niina
 author_email = niina.toru.68u@gmail.com
 url = https://github.com/ToruNiina/libasd


### PR DESCRIPTION
The source distribution patch PR (#12)  resulted in a version bump to v1.5.6 but the GitHub Workflows to publish this to PyPI failed to complete for [various reasons](https://github.com/ToruNiina/libasd/actions/runs/3445184448).

For example the Linux distribution failed because the package was not built with version 1.5.6 but rather 1.5.5 and PyPI does not permit uploading the same package version so the upload [failed with 400 error](https://github.com/ToruNiina/libasd/actions/runs/3445184448/jobs/5748623171).

OSX builds completed.

One source distribution completed whilst others [failed](https://github.com/ToruNiina/libasd/actions/runs/3445184448/jobs/5748604094) because of 400 bad requests but lack further details.

I think this version bump may resolve those issues.